### PR TITLE
Fix `electron-packager` script path

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "package-win": "npm run build && build --win --x64",
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
-    "electron-packager": "electron-packager . Autocap",
+    "electron-packager": "electron-packager app Autocap",
     "cleanup": "mop -v"
   },
   "build": {


### PR DESCRIPTION
At least for me on Linux, running with the current directory as the subject didn't work. It seemed to be expecting `app` instead, so I tried that and it worked.